### PR TITLE
added name to evironment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,4 @@
+name:hallucinating_scenes
 channels:
   - defaults
   - pytorch


### PR DESCRIPTION
added name tag, before environment could not be created since the name as per the README instructio as the environment name was missing

conda env create -f environment.yml -n hallucinating-scenes conda activate hallucinating-scenes